### PR TITLE
Bug fix when specifying S3 object params

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ var backup = new DynamoBackup({
     aws: { /* AWS general configuration options */
         region: /* AWS region */,
         accessKeyId: /* AWS access key */,
-        secretAccessKey: /* AWS secret key */
+        secretAccessKey: /* AWS secret key */,
+        objectParams: {
+            /* optional S3 object properties, such as encryption or storage class*/
+        }
     },
     excludedTables: ['development-table1', 'development-table2'],
     readPercentage: .5,
@@ -79,7 +82,10 @@ var options = {
     aws: { /* AWS general configuration options */
         region: /* AWS region */,
         accessKeyId: /* AWS access key */,
-        secretAccessKey: /* AWS secret key */
+        secretAccessKey: /* AWS secret key */,
+        objectParams: {
+            /* optional S3 object properties, such as encryption or storage class*/
+        }
     },
     excludedTables: /* tables to exclude from backup */,
     includedTables: /* only back up these tables */

--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -50,7 +50,7 @@ DynamoBackup.prototype.backupTable = function (tableName, backupPath, callback) 
         objectName: path.join(backupPath, tableName + '.json'),
         stream: stream,
         debug: self.debug,
-    }, self.awsConfig)
+    }, JSON.parse(JSON.stringify(self.awsConfig)))
 
     /**
      * Map key names if they're provided


### PR DESCRIPTION
This fixes a bug which reveals itself when you use the `objectParams` property. Example:

```
let backup = new DynamoBackup({
        aws: {
          region: myRegion,
          accessKeyId: myKey,
          secretAccessKey: mySecret,
          objectParams: {
            ServerSideEncryption: 'AES256',
            StorageClass: 'STANDARD_IA'
          }
        },
        includedTables: ['table1','table2],
        readPercentage: .85,
        bucket: myBucket
      });
```

The `objectParam` property is copied over to the S3 params object which is handed off to the Uploader (s3-streaming-upload). The problem is that the Uploader appends some other data to the params, such as the `Key` of the file, and the data spills over to the `awsConfig` object on `DynamoBackup`. This happens because `Object.assign` on line 48 performs a shallow copy, and the original `objectParams` object is changed.

The symptom is that if you backup several tables simultaneously, they will all share the same `Key` property, and only 1 .json file will be saved in the bucket.

The solution was to perform a [deep copy of the object using JSON.stringify and JSON.parse](https://stackoverflow.com/a/5344074/263129)

I also included documentation on how to use the objectParams property.