### PR TITLE
Logicchanges

### DIFF
--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -152,7 +152,7 @@ DynamoBackup.prototype._copyTable = function (tableName, itemsReceived, callback
         }
 
         const readPercentage = self.readPercentage;
-        const limit = Math.max((schema.ProvisionedThroughput.ReadCapacityUnits * readPercentage) | 0, 1);
+        const limit = Math.max((schema.ProvisionedThroughput.ReadCapacityUnits / (schema.TableSizeBytes / schema.ItemCount / 4096 * 2 ) * readPercentage) | 0, 1);
 
         async.parallel([
             cb => self._copySchema(tableName, schema, cb),

--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -152,8 +152,7 @@ DynamoBackup.prototype._copyTable = function (tableName, itemsReceived, callback
         }
 
         const readPercentage = self.readPercentage;
-        const limit = Math.max((schema.ProvisionedThroughput.ReadCapacityUnits / (schema.TableSizeBytes / schema.ItemCount / (4096 * 2) ) * readPercentage) | 0, 1);   // The logic behind this: ReadCapacityUnits divided average size of one item ( total tablesize in bytes divided by 4KB(4096 bytes) boundry multiplied by two for evenetual consistency).   
-
+        const limit = Math.max((schema.ProvisionedThroughput.ReadCapacityUnits / (schema.TableSizeBytes / schema.ItemCount / (4096 * 2) ) * readPercentage) | 0, 1);   // The logic behind this: ReadCapacityUnits divided average size of one item ( total tablesize in bytes divided by 4KB(4096 bytes) boundry multiplied by two for evenetual consistency).
         async.parallel([
             cb => self._copySchema(tableName, schema, cb),
             cb => self._streamItems(tableName, null, limit, itemsReceived, cb)

--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -152,7 +152,7 @@ DynamoBackup.prototype._copyTable = function (tableName, itemsReceived, callback
         }
 
         const readPercentage = self.readPercentage;
-        const limit = Math.max((schema.ProvisionedThroughput.ReadCapacityUnits / (schema.TableSizeBytes / schema.ItemCount / 4096 * 2 ) * readPercentage) | 0, 1);
+        const limit = Math.max((schema.ProvisionedThroughput.ReadCapacityUnits / (schema.TableSizeBytes / schema.ItemCount / 4096 * 2 ) * readPercentage) | 0, 1);   // The logic behind this: ReadCapacityUnits multiplied by the total tablesize in bytes divided by the count of documents and troughput capacity multiplied by two 
 
         async.parallel([
             cb => self._copySchema(tableName, schema, cb),

--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -152,7 +152,7 @@ DynamoBackup.prototype._copyTable = function (tableName, itemsReceived, callback
         }
 
         const readPercentage = self.readPercentage;
-        const limit = Math.max((schema.ProvisionedThroughput.ReadCapacityUnits / (schema.TableSizeBytes / schema.ItemCount / 4096 * 2 ) * readPercentage) | 0, 1);   // The logic behind this: ReadCapacityUnits multiplied by the total tablesize in bytes divided by the count of documents and troughput capacity multiplied by two 
+        const limit = Math.max((schema.ProvisionedThroughput.ReadCapacityUnits / (schema.TableSizeBytes / schema.ItemCount / (4096 * 2) ) * readPercentage) | 0, 1);   // The logic behind this: ReadCapacityUnits divided average size of one item ( total tablesize in bytes divided by 4KB(4096 bytes) boundry multiplied by two for evenetual consistency).   
 
         async.parallel([
             cb => self._copySchema(tableName, schema, cb),


### PR DESCRIPTION
// The logic behind this: ReadCapacityUnits divided average size of one item ( total tablesize in bytes divided by 4KB(4096 bytes) boundry multiplied by two for evenetual consistency).